### PR TITLE
Corrección GitIgnore. Evita que desaparezca Ayuda_Seguridad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,8 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Excepciones para Ayuda_Seguridad
+!asis22k24proy2/Codigo/Componentes/Seguridad/EjecucionSeguridad/EjecucionSeguridad/bin/Debug/Ayuda_Seguridad/
+!asis22k24proy2/Codigo/Componentes/Seguridad/Ayuda_Seguridad/
+


### PR DESCRIPTION
Corrección GitIgnore. Para evitar que la carpeta Ayuda_Seguridad desaparezca de la carpeta de Ejecución.